### PR TITLE
Include Discord attachment URLs on bridged Minecraft messages

### DIFF
--- a/src/main/java/lv/mtm123/cvcancer/jda/listeners/MessageListener.java
+++ b/src/main/java/lv/mtm123/cvcancer/jda/listeners/MessageListener.java
@@ -61,7 +61,7 @@ public class MessageListener extends ListenerAdapter {
                 });
     }
 
-    private Object getEffectiveUrl(Message.Attachment a) {
+    private String getEffectiveUrl(Message.Attachment a) {
         return a.isImage() ? a.getProxyUrl() : a.getUrl();
     }
 


### PR DESCRIPTION
This PR adds Discord attachment URLs to the corresponding Minecraft message.

This is mainly because people can send images on Discord as attachments and inside Minecraft the message would appear blank.
![Minecraft chat screenshot showing an empty message](https://i.imgur.com/tyU9oFF.png)